### PR TITLE
Add scout location and profile setup screen

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -14,6 +14,7 @@ import '../screens/team_detail_screen.dart';
 import '../screens/pennant_race_screen.dart';
 import '../screens/tournament_screen.dart';
 import '../screens/draft_screen.dart';
+import '../screens/scout_profile_screen.dart';
 
 import 'theme.dart';
 import '../models/player/player.dart';
@@ -37,6 +38,7 @@ class ScoutGameApp extends StatelessWidget {
         '/load': (context) => const LoadGameScreen(),
         '/schools': (context) => const SchoolListScreen(),
         '/scoutSkill': (context) => const ScoutSkillScreen(),
+        '/scoutProfile': (context) => const ScoutProfileScreen(),
         '/teamRequests': (context) => const TeamRequestsScreen(),
         '/professionalTeams': (context) => const ProfessionalTeamsScreen(),
         '/pennantRace': (context) => const PennantRaceScreen(),

--- a/lib/models/game/game.dart
+++ b/lib/models/game/game.dart
@@ -63,6 +63,7 @@ class GameAction {
 
 class Game {
   final String scoutName; // スカウト名
+  final String scoutPrefecture; // スカウトの所在地
   final int scoutSkill; // スカウトスキル 0-100
   final int currentYear; // 現在の年
   final int currentMonth; // 現在の月（1-12）
@@ -86,9 +87,10 @@ class Game {
   final List<HighSchoolTournament> highSchoolTournaments; // 高校野球大会
   final bool? hasGradeUpProcessedThisYear; // 今年の学年アップ処理が実行済みか
   final bool? hasNewYearProcessedThisYear; // 今年の新年度処理が実行済みか
-  
+
   Game({
     required this.scoutName,
+    required this.scoutPrefecture,
     required this.scoutSkill,
     required this.currentYear,
     required this.currentMonth,
@@ -361,6 +363,7 @@ class Game {
 
   Map<String, dynamic> toJson() => {
     'scoutName': scoutName,
+    'scoutPrefecture': scoutPrefecture,
     'scoutSkill': scoutSkill,
     'currentYear': currentYear,
     'currentMonth': currentMonth,
@@ -430,12 +433,14 @@ class Game {
       highSchoolTournaments: (json['highSchoolTournaments'] as List?)?.map((t) => HighSchoolTournament.fromJson(t)).toList() ?? [],
       hasGradeUpProcessedThisYear: json['hasGradeUpProcessedThisYear'] as bool? ?? false,
       hasNewYearProcessedThisYear: json['hasNewYearProcessedThisYear'] as bool? ?? false,
+      scoutPrefecture: json['scoutPrefecture'] as String? ?? '',
     );
   }
   
   // コピーメソッド
   Game copyWith({
     String? scoutName,
+    String? scoutPrefecture,
     int? scoutSkill,
     int? currentYear,
     int? currentMonth,
@@ -462,6 +467,7 @@ class Game {
   }) {
     return Game(
       scoutName: scoutName ?? this.scoutName,
+      scoutPrefecture: scoutPrefecture ?? this.scoutPrefecture,
       scoutSkill: scoutSkill ?? this.scoutSkill,
       currentYear: currentYear ?? this.currentYear,
       currentMonth: currentMonth ?? this.currentMonth,

--- a/lib/models/scouting/scout.dart
+++ b/lib/models/scouting/scout.dart
@@ -51,6 +51,7 @@ const Map<ScoutSkill, IconData> skillIcons = {
 // スカウトクラス
 class Scout {
   final String name;
+  final String prefecture;
   final int level;
   final int experience;
   final int maxExperience;
@@ -68,6 +69,7 @@ class Scout {
   
   const Scout({
     required this.name,
+    required this.prefecture,
     required this.level,
     required this.experience,
     required this.maxExperience,
@@ -85,9 +87,10 @@ class Scout {
   });
 
   // デフォルトスカウト作成
-  factory Scout.createDefault(String name) {
+  factory Scout.createDefault(String name, {String prefecture = '未設定'}) {
     return Scout(
       name: name,
+      prefecture: prefecture,
       level: 1,
       experience: 0,
       maxExperience: 100,
@@ -221,6 +224,7 @@ class Scout {
   // JSON変換
   Map<String, dynamic> toJson() => {
     'name': name,
+    'prefecture': prefecture,
     'level': level,
     'experience': experience,
     'maxExperience': maxExperience,
@@ -252,6 +256,7 @@ class Scout {
 
     return Scout(
       name: json['name'] as String,
+      prefecture: json['prefecture'] as String? ?? '未設定',
       level: json['level'] as int,
       experience: json['experience'] as int,
       maxExperience: json['maxExperience'] as int,
@@ -272,6 +277,7 @@ class Scout {
   // コピーメソッド
   Scout copyWith({
     String? name,
+    String? prefecture,
     int? level,
     int? experience,
     int? maxExperience,
@@ -289,6 +295,7 @@ class Scout {
   }) {
     return Scout(
       name: name ?? this.name,
+      prefecture: prefecture ?? this.prefecture,
       level: level ?? this.level,
       experience: experience ?? this.experience,
       maxExperience: maxExperience ?? this.maxExperience,
@@ -311,13 +318,14 @@ class Scout {
     if (identical(this, other)) return true;
     return other is Scout &&
         other.name == name &&
+        other.prefecture == prefecture &&
         other.level == level &&
         other.experience == experience;
   }
 
   @override
   int get hashCode {
-    return name.hashCode ^ level.hashCode ^ experience.hashCode;
+    return name.hashCode ^ prefecture.hashCode ^ level.hashCode ^ experience.hashCode;
   }
 
   @override

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -78,7 +78,7 @@ class _GameScreenState extends State<GameScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text('${game.scoutName}のダッシュボード'),
+        title: Text('${game.scoutPrefecture} - ${game.scoutName}のダッシュボード'),
       ),
       drawer: Drawer(
         child: ListView(
@@ -88,13 +88,15 @@ class _GameScreenState extends State<GameScreen> {
               decoration: BoxDecoration(color: Theme.of(context).primaryColor),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(game.scoutName, style: const TextStyle(color: Colors.white, fontSize: 20)),
-                  const SizedBox(height: 8),
-                  Text('ランク: Freelance', style: const TextStyle(color: Colors.white70)),
-                ],
-              ),
+              children: [
+                Text(game.scoutName, style: const TextStyle(color: Colors.white, fontSize: 20)),
+                const SizedBox(height: 8),
+                Text('所在地: ${game.scoutPrefecture}', style: const TextStyle(color: Colors.white70)),
+                const SizedBox(height: 4),
+                Text('ランク: Freelance', style: const TextStyle(color: Colors.white70)),
+              ],
             ),
+          ),
             ListTile(
               leading: const Icon(Icons.school),
               title: const Text('学校リスト'),

--- a/lib/screens/main_menu_screen.dart
+++ b/lib/screens/main_menu_screen.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-import '../services/game_manager.dart';
-import '../services/data_service.dart';
-import 'game_screen.dart';
+import 'scout_profile_screen.dart';
 
 class MainMenuScreen extends StatefulWidget {
   const MainMenuScreen({super.key});
@@ -12,96 +9,6 @@ class MainMenuScreen extends StatefulWidget {
 }
 
 class _MainMenuScreenState extends State<MainMenuScreen> {
-  Future<void> _startNewGame(BuildContext context) async {
-    final gameManager = Provider.of<GameManager>(context, listen: false);
-    final dataService = Provider.of<DataService>(context, listen: false);
-    
-    // 既存のDBを削除して新規作成
-    await dataService.deleteDatabase();
-    
-    // 進捗ダイアログ表示
-    showDialog(
-      context: context,
-      barrierDismissible: false,
-      builder: (context) => AlertDialog(
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: const [
-            Text('選手を作成しています...'),
-            SizedBox(height: 24),
-            LinearProgressIndicator(),
-          ],
-        ),
-      ),
-    );
-    try {
-      // ニューゲーム開始
-      await gameManager.startNewGameWithDb('あなた', dataService);
-      
-      // デバッグ: ニューゲーム開始後の状態を確認
-      print('MainMenuScreen._startNewGame: ニューゲーム開始後の状態確認');
-      print('MainMenuScreen._startNewGame: gameManager.currentGame = ${gameManager.currentGame != null ? "loaded" : "null"}');
-      if (gameManager.currentGame != null) {
-        print('MainMenuScreen._startNewGame: 学校数: ${gameManager.currentGame!.schools.length}');
-        print('MainMenuScreen._startNewGame: 発掘選手数: ${gameManager.currentGame!.discoveredPlayerIds.length}');
-      }
-      
-      // Providerの状態を強制的に更新
-      if (context.mounted) {
-        setState(() {});
-      }
-      
-      // 少し待機してからゲーム画面に遷移
-      await Future.delayed(const Duration(milliseconds: 100));
-      
-    } catch (e) {
-      print('MainMenuScreen._startNewGame: ニューゲーム開始でエラーが発生しました: $e');
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('ゲームの開始に失敗しました: $e')),
-        );
-      }
-      return;
-    } finally {
-      // 確実にダイアログを閉じる
-      if (context.mounted) {
-        Navigator.pop(context);
-        print('ダイアログを閉じました');
-      }
-    }
-    if (!context.mounted) return;
-    
-    // SnackBarをクリア
-    ScaffoldMessenger.of(context).clearSnackBars();
-    
-    // 画面を強制リビルド
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (context.mounted) {
-        setState(() {});
-      }
-    });
-    
-    // ゲームの状態を最終確認
-    if (gameManager.currentGame == null) {
-      print('MainMenuScreen._startNewGame: エラー - ゲームが開始されていません');
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('ゲームの開始に失敗しました。もう一度お試しください。')),
-        );
-      }
-      return;
-    }
-    
-    print('MainMenuScreen._startNewGame: ゲーム画面に遷移開始');
-    
-    // 前の画面スタックをクリアしてゲーム画面に遷移
-    Navigator.pushAndRemoveUntil(
-      context,
-      MaterialPageRoute(builder: (context) => const GameScreen()),
-      (route) => false,
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -113,7 +20,13 @@ class _MainMenuScreenState extends State<MainMenuScreen> {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             ElevatedButton(
-              onPressed: () => _startNewGame(context),
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (context) => const ScoutProfileScreen()),
+                );
+              },
               child: const Text('ニューゲーム'),
             ),
             const SizedBox(height: 20),

--- a/lib/screens/player_list_screen.dart
+++ b/lib/screens/player_list_screen.dart
@@ -146,8 +146,17 @@ class _PlayerListScreenState extends State<PlayerListScreen> with SingleTickerPr
   @override
   Widget build(BuildContext context) {
     final gameManager = Provider.of<GameManager>(context);
-    // 全学校の全選手を取得（注目選手を含むため）
-    final List<Player> allPlayers = gameManager.getAllPlayers();
+    // 全学校の全選手を取得し、所在地でフィルタリング
+    final scoutPrefecture = gameManager.currentGame?.scoutPrefecture;
+    final schoolPrefMap = {
+      for (var s in gameManager.currentGame?.schools ?? []) s.name: s.prefecture
+    };
+    final List<Player> allPlayers = gameManager
+        .getAllPlayers()
+        .where((player) {
+          if (scoutPrefecture == null || scoutPrefecture.isEmpty) return true;
+          return schoolPrefMap[player.school] == scoutPrefecture;
+        }).toList();
     
     return Scaffold(
       appBar: AppBar(

--- a/lib/screens/school_list_screen.dart
+++ b/lib/screens/school_list_screen.dart
@@ -20,6 +20,16 @@ class _SchoolListScreenState extends State<SchoolListScreen> {
   static const int _schoolsPerPage = 50;
 
   @override
+  void initState() {
+    super.initState();
+    final gameManager = Provider.of<GameManager>(context, listen: false);
+    final prefecture = gameManager.currentGame?.scoutPrefecture;
+    if (prefecture != null && prefecture.isNotEmpty) {
+      _selectedPrefecture = prefecture;
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final gameManager = Provider.of<GameManager>(context);
     final game = gameManager.currentGame;

--- a/lib/screens/scout_profile_screen.dart
+++ b/lib/screens/scout_profile_screen.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/game_manager.dart';
+import '../services/data_service.dart';
+import '../services/default_school_data.dart';
+import 'game_screen.dart';
+
+class ScoutProfileScreen extends StatefulWidget {
+  const ScoutProfileScreen({super.key});
+
+  @override
+  State<ScoutProfileScreen> createState() => _ScoutProfileScreenState();
+}
+
+class _ScoutProfileScreenState extends State<ScoutProfileScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final TextEditingController _nameController =
+      TextEditingController(text: 'あなた');
+  String _selectedPrefecture = DefaultSchoolData.prefectures.first;
+
+  Future<void> _startGame(BuildContext context) async {
+    if (!_formKey.currentState!.validate()) return;
+
+    final gameManager = Provider.of<GameManager>(context, listen: false);
+    final dataService = Provider.of<DataService>(context, listen: false);
+
+    await dataService.deleteDatabase();
+
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => const AlertDialog(
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('ゲームを準備しています...'),
+            SizedBox(height: 24),
+            LinearProgressIndicator(),
+          ],
+        ),
+      ),
+    );
+
+    try {
+      await gameManager.startNewGameWithDb(
+        _nameController.text,
+        _selectedPrefecture,
+        dataService,
+      );
+    } finally {
+      if (mounted) Navigator.pop(context);
+    }
+
+    if (!mounted) return;
+
+    Navigator.pushAndRemoveUntil(
+      context,
+      MaterialPageRoute(builder: (_) => const GameScreen()),
+      (route) => false,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('スカウトプロフィール設定')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(labelText: 'スカウト名'),
+                validator: (value) =>
+                    value == null || value.isEmpty ? '名前を入力してください' : null,
+              ),
+              const SizedBox(height: 16),
+              DropdownButtonFormField<String>(
+                value: _selectedPrefecture,
+                decoration: const InputDecoration(labelText: '所在地'),
+                items: DefaultSchoolData.prefectures
+                    .map((p) => DropdownMenuItem(
+                          value: p,
+                          child: Text(p),
+                        ))
+                    .toList(),
+                onChanged: (value) {
+                  if (value != null) {
+                    setState(() {
+                      _selectedPrefecture = value;
+                    });
+                  }
+                },
+              ),
+              const Spacer(),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () => _startGame(context),
+                  child: const Text('ゲーム開始'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/scout_skill_screen.dart
+++ b/lib/screens/scout_skill_screen.dart
@@ -26,7 +26,9 @@ class _ScoutSkillScreenState extends State<ScoutSkillScreen> {
     }
 
     // スカウト情報を取得
-    final scout = gameManager.currentScout ?? Scout.createDefault(game.scoutName);
+    final scout = gameManager.currentScout ??
+        Scout.createDefault(game.scoutName,
+            prefecture: game.scoutPrefecture);
 
     return Scaffold(
       appBar: AppBar(
@@ -81,6 +83,8 @@ class _ScoutSkillScreenState extends State<ScoutSkillScreen> {
                 ),
               ],
             ),
+            const SizedBox(height: 8),
+            _infoRow('所在地', scout.prefecture, Icons.location_on),
             const SizedBox(height: 12),
             Row(
               children: [

--- a/lib/services/data_service.dart
+++ b/lib/services/data_service.dart
@@ -72,6 +72,7 @@ class DataService {
       // Gameオブジェクトを構築
       final gameData = {
         'scoutName': gameInfo.first['scoutName'],
+        'scoutPrefecture': gameInfo.first['scoutPrefecture'],
         'currentYear': gameInfo.first['currentYear'],
         'currentMonth': gameInfo.first['currentMonth'],
         'currentWeekOfMonth': gameInfo.first['currentWeekOfMonth'],
@@ -969,6 +970,7 @@ class DataService {
       CREATE TABLE GameInfo (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         scoutName TEXT NOT NULL,
+        scoutPrefecture TEXT NOT NULL,
         currentYear INTEGER NOT NULL,
         currentMonth INTEGER NOT NULL,
         currentWeekOfMonth INTEGER NOT NULL,
@@ -2154,6 +2156,7 @@ class DataService {
     // GameInfoテーブルに保存
     await txn.insert('GameInfo', {
       'scoutName': data['scoutName'] ?? '',
+      'scoutPrefecture': data['scoutPrefecture'] ?? '',
       'currentYear': data['currentYear'] ?? 1,
       'currentMonth': data['currentMonth'] ?? 4,
       'currentWeekOfMonth': data['currentWeekOfMonth'] ?? 1,

--- a/lib/services/default_school_data.dart
+++ b/lib/services/default_school_data.dart
@@ -13,6 +13,8 @@ class DefaultSchoolData {
     '熊本県', '大分県', '宮崎県', '鹿児島県', '沖縄県'
   ];
 
+  static List<String> get prefectures => _prefectures;
+
   // 各都道府県の主要都市・地域
   static const Map<String, List<String>> _majorCities = {
     '北海道': ['札幌', '旭川', '函館', '小樽', '室蘭', '苫小牧', '帯広', '北見', '釧路', '網走'],

--- a/lib/services/game_manager.dart
+++ b/lib/services/game_manager.dart
@@ -561,7 +561,7 @@ class GameManager {
     }
   }
 
-  Future<void> startNewGameWithDb(String scoutName, DataService dataService) async {
+  Future<void> startNewGameWithDb(String scoutName, String scoutPrefecture, DataService dataService) async {
     try {
       // 初期データ投入（初回のみ）
       await dataService.insertInitialData();
@@ -572,11 +572,12 @@ class GameManager {
       final schools = <School>[];
       final players = <Player>[];
       // スカウトインスタンス生成
-      _currentScout = Scout.createDefault(scoutName);
+      _currentScout = Scout.createDefault(scoutName, prefecture: scoutPrefecture);
       
       // Gameインスタンス生成
       _currentGame = Game(
         scoutName: scoutName,
+        scoutPrefecture: scoutPrefecture,
         scoutSkill: 50,
         currentYear: DateTime.now().year,
         currentMonth: 4,
@@ -3303,7 +3304,9 @@ class GameManager {
           
           final result = await scouting.ActionService.interview(
             targetPlayer: targetPlayer,
-            scout: _currentScout ?? Scout.createDefault('デフォルトスカウト'),
+            scout: _currentScout ??
+                Scout.createDefault('デフォルトスカウト',
+                    prefecture: _currentGame!.scoutPrefecture),
             scoutSkills: _currentGame!.scoutSkills,
             currentWeek: _currentGame!.currentWeekOfMonth,
           );

--- a/lib/widgets/tournament_list_widget.dart
+++ b/lib/widgets/tournament_list_widget.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../models/game/high_school_tournament.dart';
 import '../models/school/school.dart';
+import '../services/game_manager.dart';
 import 'tournament_bracket_widget.dart';
 
 class TournamentListWidget extends StatefulWidget {
@@ -21,6 +23,13 @@ class _TournamentListWidgetState extends State<TournamentListWidget> {
   String? _selectedPrefecture;
   String? _selectedYear;
   bool _showArchived = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final gameManager = Provider.of<GameManager>(context, listen: false);
+    _selectedPrefecture = gameManager.currentGame?.scoutPrefecture;
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Summary
- expose default prefecture list
- add profile setup screen to choose scout name and location
- link new game flow to profile setup screen and register route

## Testing
- `dart format lib/app/app.dart lib/screens/main_menu_screen.dart lib/services/default_school_data.dart lib/screens/scout_profile_screen.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0617484808327b367fe476fecafc5